### PR TITLE
BUP-1: Sowing Beans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 temp
 .DS_Store
 .openzeppelin
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Beanstalk-Budget
+
+The smart contract for the initial Beanstalk Budgets.
+
+The Development Budget Proxy is deployed here:
+0x83A758a6a24FE27312C1f8BDa7F3277993b64783
+
+The Marketing Budget Proxy is deployed here:
+0xAA420e97534aB55637957e868b658193b112A551
+
+The Budget Contract is deployed here:
+0xbE9130192E4461696288f974F9Fd66F28EC6BbA1

--- a/contracts/Budget.sol
+++ b/contracts/Budget.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.6;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./interfaces/IBeanstalk.sol";
 
 /**
  * @author publius
@@ -13,12 +14,22 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract Budget is OwnableUpgradeable {
 
     address public tokenAddress;
+    address public beanstalkAddress;
+
+    uint256 constant UINT256_MAX = 2**255+1;
     
     event Payment(address indexed payee, uint256 amount);
 
-    function initialize(address _tokenAddress) public initializer {
+    function initialize(address _tokenAddress, address _beanstalkAddress) public initializer {
         tokenAddress = _tokenAddress;
+        beanstalkAddress = _beanstalkAddress;
+        IERC20(tokenAddress).approve(beanstalkAddress, UINT256_MAX);
         __Ownable_init();
+    }
+
+    function setBeanstalk(address _beanstalkAddress) public onlyOwner {
+        beanstalkAddress = _beanstalkAddress;
+        IERC20(tokenAddress).approve(beanstalkAddress, UINT256_MAX);
     }
 
     function balance() public view returns (uint256) {
@@ -26,7 +37,7 @@ contract Budget is OwnableUpgradeable {
     }
 
     /**
-     * @dev Pay 
+     * @dev Pay Beans to a payee.
      * @param payee the address that is being paid.
      * @param amount the amount that is being paid.
      */
@@ -34,7 +45,25 @@ contract Budget is OwnableUpgradeable {
         IERC20 token = IERC20(tokenAddress);
         require(token.balanceOf(address(this)) >= amount, "Budget: Insufficient funds");
         token.transfer(payee, amount);
-
         emit Payment(payee, amount);
+    }
+
+    /**
+     * @dev Sow Beans on the behalf of a payee.
+     * @param amount the amount of Beans to sow.
+     */
+    function sow(uint256 amount) public onlyOwner {
+        IBeanstalk(beanstalkAddress).sowBeans(amount);
+    }
+
+    /**
+     * @dev Pay a plot to a payee.
+     * @param payee the address that is being paid.
+     * @param id the id of the plot being paid.
+     * @param start the start index of the plot being paid.
+     * @param end the end index of the plot being paid.
+     */
+    function payPlot(address payee, uint256 id, uint256 start, uint256 end) public onlyOwner {
+        IBeanstalk(beanstalkAddress).transferPlot(address(this), payee, id, start, end);
     }
 }

--- a/contracts/BudgetOld.sol
+++ b/contracts/BudgetOld.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.6;
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./interfaces/IBeanstalk.sol";
+
+/**
+ * @author publius
+ * @title Budget
+ */
+
+contract BudgetOld is OwnableUpgradeable {
+
+    address public tokenAddress;
+
+    uint256 constant UINT256_MAX = 2**255+1;
+    
+    event Payment(address indexed payee, uint256 amount);
+
+    function initialize(address _tokenAddress) public initializer {
+        tokenAddress = _tokenAddress;
+        __Ownable_init();
+    }
+
+    function balance() public view returns (uint256) {
+        return IERC20(tokenAddress).balanceOf(address(this));
+    }
+
+    /**
+     * @dev Pay Beans to a payee.
+     * @param payee the address that is being paid.
+     * @param amount the amount that is being paid.
+     */
+    function pay(address payee, uint256 amount) public onlyOwner {
+        IERC20 token = IERC20(tokenAddress);
+        require(token.balanceOf(address(this)) >= amount, "Budget: Insufficient funds");
+        token.transfer(payee, amount);
+
+        emit Payment(payee, amount);
+    }
+}

--- a/contracts/interfaces/IBeanstalk.sol
+++ b/contracts/interfaces/IBeanstalk.sol
@@ -1,0 +1,15 @@
+/**
+ * SPDX-License-Identifier: MIT
+**/
+
+pragma solidity ^0.8.6;
+
+/**
+ * @author Publius
+ * @title Bean Interface
+**/
+abstract contract IBeanstalk {
+
+    function sowBeans(uint256 amount) external virtual returns (uint256);
+    function transferPlot(address sender, address recipient, uint256 id, uint256 start, uint256 end) external virtual;
+}

--- a/contracts/mock/MockFieldFacet/AppStorage.sol
+++ b/contracts/mock/MockFieldFacet/AppStorage.sol
@@ -1,0 +1,43 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity ^0.8.6;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @author Publius
+ * @title App Storage defines the state object for Beanstalk.
+**/
+contract Account {
+
+    struct Field {
+        mapping(uint256 => uint256) plots;
+        mapping(address => uint256) podAllowances;
+    }
+
+    struct State {
+        Field field;
+    }
+}
+
+contract Storage {
+    struct Contracts {
+        address bean;
+    }
+
+    // Field
+
+    struct Field {
+        uint256 soil;
+        uint256 pods;
+        uint256 harvested;
+        uint256 harvestable;
+    }
+}
+
+struct AppStorage {
+    Storage.Contracts c;
+    Storage.Field f;
+    mapping (address => Account.State) a;
+}

--- a/contracts/mock/MockFieldFacet/Dibbler.sol
+++ b/contracts/mock/MockFieldFacet/Dibbler.sol
@@ -1,0 +1,84 @@
+/**
+ * SPDX-License-Identifier: MIT
+**/
+
+pragma solidity ^0.8.6;
+
+import "./AppStorage.sol";
+import "../../mock/MockToken.sol";
+
+/**
+ * @author Publius
+ * @title Dibbler
+**/
+contract Dibbler {
+
+    AppStorage internal s;
+    uint32 private constant MAX_UINT32 = 2**32-1;
+
+    event Sow(address indexed account, uint256 index, uint256 beans, uint256 pods);
+
+    /**
+     * Getters
+    **/
+
+    function totalPods() public view returns (uint256) {
+        return s.f.pods - s.f.harvested;
+    }
+
+    function podIndex() public view returns (uint256) {
+        return s.f.pods;
+    }
+
+    function harvestableIndex() public view returns (uint256) {
+        return s.f.harvestable;
+    }
+
+    function harvestedIndex() public view returns (uint256) {
+        return s.f.harvested;
+    }
+
+    function totalHarvestable() public view returns (uint256) {
+        return s.f.harvestable - s.f.harvested;
+    }
+
+    function totalUnripenedPods() public view returns (uint256) {
+        return s.f.pods - s.f.harvestable;
+    }
+
+    function plot(address account, uint256 plotId) public view returns (uint256) {
+        return s.a[account].field.plots[plotId];
+    }
+
+    /**
+     * Internal
+    **/
+
+    function _sowBeans(uint256 amount) internal returns (uint256) {
+        require(amount > 0, "Field: Must purchase non-zero amount.");
+        burn(amount);
+        sowPlot(msg.sender, amount, amount);
+        incrementTotalPods(amount);
+
+        return amount;
+    }
+
+    function incrementTotalPods(uint256 amount) internal {
+        s.f.pods = s.f.pods + amount;
+    }
+
+    function sowPlot(address account, uint256 beans, uint256 pods) internal {
+        s.a[account].field.plots[podIndex()] = pods;
+        emit Sow(msg.sender, podIndex(), beans, pods);
+    }
+
+    function burn(uint256 amount) private {
+        MockToken(s.c.bean).burn(address(this), amount);
+    }
+
+    /**
+     * Shed
+    **/
+
+
+}

--- a/contracts/mock/MockFieldFacet/FieldFacet.sol
+++ b/contracts/mock/MockFieldFacet/FieldFacet.sol
@@ -1,0 +1,56 @@
+/**
+ * SPDX-License-Identifier: MIT
+**/
+
+pragma solidity ^0.8.6;
+
+import "./PodTransfer.sol";
+
+/**
+ * @author Publius
+ * @title Field sows Beans and transfers Pods.
+**/
+contract FieldFacet is PodTransfer {
+
+    uint256 constant UINT256_MAX = 2**255+1;
+
+    event PlotTransfer(address indexed from, address indexed to, uint256 indexed id, uint256 pods);
+    event PodApproval(address indexed owner, address indexed spender, uint256 pods);
+
+    constructor(address bean) public {  
+        s.c.bean = bean;
+    }
+
+    function sowBeans(uint256 amount) external returns (uint256) {
+        MockToken(s.c.bean).transferFrom(msg.sender, address(this), amount);
+        return _sowBeans(amount);
+    }
+
+    /**
+     * Transfer
+    **/
+
+    function transferPlot(address sender, address recipient, uint256 id, uint256 start, uint256 end)
+        external
+    {
+        require(sender != address(0), "Field: Transfer from 0 address.");
+        require(recipient != address(0), "Field: Transfer to 0 address.");
+        require(end > start, "Field: Pod range invalid.");
+        uint256 amount = plot(sender, id);
+        require(amount > 0, "Field: Plot not owned by user.");
+        require(amount >= end, "Field: Pod range too long.");
+        amount = end - start;
+        insertPlot(recipient,id + start,amount);
+        removePlot(sender,id,start,end);
+        if (msg.sender != sender && allowancePods(sender, msg.sender) != UINT256_MAX) {
+                decrementAllowancePods(sender, msg.sender, amount);
+        }
+        emit PlotTransfer(sender, recipient, id + start, amount);
+    }
+
+    function approvePods(address spender, uint256 amount) external {
+        require(spender != address(0), "Field: Pod Approve to 0 address.");
+        setAllowancePods(msg.sender, spender, amount);
+        emit PodApproval(msg.sender, spender, amount);
+    }
+}

--- a/contracts/mock/MockFieldFacet/PodTransfer.sol
+++ b/contracts/mock/MockFieldFacet/PodTransfer.sol
@@ -1,0 +1,51 @@
+/**
+ * SPDX-License-Identifier: MIT
+**/
+
+pragma solidity ^0.8.6;
+
+import "./Dibbler.sol";
+
+/**
+ * @author Publius
+ * @title Pod Transfer
+**/
+contract PodTransfer is Dibbler {
+
+    /**
+     * Getters
+    **/
+
+    function allowancePods(address owner, address spender) public view returns (uint256) {
+        return s.a[owner].field.podAllowances[spender];
+    }
+
+    /**
+     * Internal
+    **/
+
+    function insertPlot(address account, uint256 id, uint256 amount) internal {
+        s.a[account].field.plots[id] = amount;
+    }
+
+    function removePlot(address account, uint256 id, uint256 start, uint256 end) internal {
+        uint256 amount = plot(account, id);
+        if (start == 0) delete s.a[account].field.plots[id];
+        else s.a[account].field.plots[id] = start;
+        if (end != amount) s.a[account].field.plots[id + end] = amount - end;
+    }
+
+    function decrementAllowancePods(address owner, address spender, uint256 amount) internal {
+        uint256 currentAllowance = allowancePods(owner, spender);
+        setAllowancePods(
+            owner,
+            spender,
+            currentAllowance - amount
+        );
+    }
+
+    function setAllowancePods(address owner, address spender, uint256 amount) internal {
+        s.a[owner].field.podAllowances[spender] = amount;
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx hardhat compile & npx hardhat test"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hardhat": "^2.6.5"
   },
   "dependencies": {
-    "@nomiclabs/hardhat-etherscan": "^2.1.6"
+    "@nomiclabs/hardhat-etherscan": "^2.1.6",
+    "dotenv": "^10.0.0"
   }
 }

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,14 +1,28 @@
 const BEAN_ADDRESS = '0xDC59ac4FeFa32293A95889Dc396682858d52e5Db'
+const BEANSTALK_ADDRESS = '0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5'
+const DEVELOPMENT_ADDRESS = '0x83A758a6a24FE27312C1f8BDa7F3277993b64783'
+const MARKETING_ADDRESS = '0xAA420e97534aB55637957e868b658193b112A551'
 
 async function main() {
   const BudgetFactory = await ethers.getContractFactory("Budget");
-  const DevelopmentBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS]);
+  const DevelopmentBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS, BEANSTALK_ADDRESS]);
   await DevelopmentBudget.deployed();
   console.log("Development Budget deployed to:", DevelopmentBudget.address);
 
-  const MarketingBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS]);
+  const MarketingBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS, BEANSTALK_ADDRESS]);
   await MarketingBudget.deployed();
   console.log("Marketing Budget deployed to:", MarketingBudget.address);
+}
+
+async function upgrade() {
+  let budget;
+  const BudgetFactory = await ethers.getContractFactory("Budget");
+  budget = await upgrades.upgradeProxy(DEVELOPMENT_ADDRESS, BudgetFactory);
+  await (await budget.setBeanstalk(BEANSTALK_ADDRESS.address)).wait()
+
+  const BudgetFactory = await ethers.getContractFactory("Budget");
+  budget = await upgrades.upgradeProxy(MARKETING_ADDRESS, BudgetFactory);
+  await (await budget.setBeanstalk(BEANSTALK_ADDRESS.address)).wait()
 }
 
 if (require.main === module) {
@@ -20,3 +34,4 @@ if (require.main === module) {
       })
   }
   exports.deploy = main
+  exports.upgrade = upgrade

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,26 +3,42 @@ const BEANSTALK_ADDRESS = '0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5'
 const DEVELOPMENT_ADDRESS = '0x83A758a6a24FE27312C1f8BDa7F3277993b64783'
 const MARKETING_ADDRESS = '0xAA420e97534aB55637957e868b658193b112A551'
 
-async function main() {
-  const BudgetFactory = await ethers.getContractFactory("Budget");
-  const DevelopmentBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS, BEANSTALK_ADDRESS]);
-  await DevelopmentBudget.deployed();
-  console.log("Development Budget deployed to:", DevelopmentBudget.address);
-
-  const MarketingBudget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS, BEANSTALK_ADDRESS]);
-  await MarketingBudget.deployed();
-  console.log("Marketing Budget deployed to:", MarketingBudget.address);
+function addCommas (nStr) {
+  nStr += ''
+  const x = nStr.split('.')
+  let x1 = x[0]
+  const x2 = x.length > 1 ? '.' + x[1] : ''
+  var rgx = /(\d+)(\d{3})/
+  while (rgx.test(x1)) {
+    x1 = x1.replace(rgx, '$1' + ',' + '$2')
+  }
+  return x1 + x2
 }
 
-async function upgrade() {
-  let budget;
-  const BudgetFactory = await ethers.getContractFactory("Budget");
-  budget = await upgrades.upgradeProxy(DEVELOPMENT_ADDRESS, BudgetFactory);
-  await (await budget.setBeanstalk(BEANSTALK_ADDRESS.address)).wait()
+function strDisplay (str) {
+  return addCommas(str.toString())
+}
 
+async function main() {
+  const BudgetFactory = await ethers.getContractFactory("Budget");
+  const budget = await upgrades.deployProxy(BudgetFactory, [BEAN_ADDRESS, BEANSTALK_ADDRESS]);
+  console.log(budget.deployTransaction);
+  const receipt = await budget.deployTransaction.wait();
+  console.log("Budget deployed to:", budget.address);
+  console.log(`Gas used: ${strDisplay(receipt.gasUsed)}`);
+}
+
+async function upgrade(account) {
   const BudgetFactory = await ethers.getContractFactory("Budget");
   budget = await upgrades.upgradeProxy(MARKETING_ADDRESS, BudgetFactory);
-  await (await budget.setBeanstalk(BEANSTALK_ADDRESS.address)).wait()
+  console.log("Marketing Address Upgraded deployed to:", MARKETING_ADDRESS);
+  await (await budget.setBeanstalk(BEANSTALK_ADDRESS)).wait()
+  console.log("Beanstalk Address set to ", BEANSTALK_ADDRESS);
+
+  budget = await upgrades.upgradeProxy(DEVELOPMENT_ADDRESS, BudgetFactory);
+  console.log("Marketing Address Upgraded deployed to:", DEVELOPMENT_ADDRESS);
+  await (await budget.setBeanstalk(BEANSTALK_ADDRESS)).wait()
+  console.log("Beanstalk Address set to ", BEANSTALK_ADDRESS);
 }
 
 if (require.main === module) {

--- a/test/Budget.js
+++ b/test/Budget.js
@@ -1,7 +1,6 @@
 const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
-
 describe("Budget", async function () {
     
     let Token;

--- a/test/Budget.js
+++ b/test/Budget.js
@@ -2,13 +2,15 @@ const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
 
-describe("Test Budget", function () {
+describe("Budget", async function () {
     
     let Token;
     let Budget;
     let owner;
     let nonowner;
     let result;
+    let field;
+    let UpBudget;
 
     beforeEach(async function () {
         [owner, nonowner] = await ethers.getSigners();
@@ -16,38 +18,137 @@ describe("Test Budget", function () {
         const MockToken = await ethers.getContractFactory("MockToken");
         Token = await MockToken.deploy();
 
-        const BudgetFactory = await ethers.getContractFactory("Budget");
-        Budget = await upgrades.deployProxy(BudgetFactory, [Token.address])
+        const FieldFacet = await ethers.getContractFactory("FieldFacet");
+        field = await FieldFacet.deploy(Token.address);
 
-        Token.mint(Budget.address, 100)
-
-    })
-
-    it("Properly shows the balance", async function () {
-        expect(await Budget.balance()).to.equal(100);
     });
 
-    it("Reverts when non-owners try to pay from the budget", async function () {
-        await expect(Budget.connect(nonowner).pay(nonowner.address, 1)).to.be.revertedWith('Ownable: caller is not the owner');
-    })
+    describe("Deploy", async function () {
 
-    describe("When owner pays from the budget", async function () {
         beforeEach(async function () {
-            result = Budget.pay(owner.address,1)
+            [owner, nonowner] = await ethers.getSigners();
+
+            const MockToken = await ethers.getContractFactory("MockToken");
+            Token = await MockToken.deploy();
+
+            const FieldFacet = await ethers.getContractFactory("FieldFacet");
+            field = await FieldFacet.deploy(Token.address);
+
+            const BudgetFactory = await ethers.getContractFactory("Budget");
+            Budget = await upgrades.deployProxy(BudgetFactory, [Token.address, field.address])
+
+            Token.mint(Budget.address, 100)
+        });
+
+        it("Properly shows the balance", async function () {
+            expect(await Budget.balance()).to.equal(100);
+        });
+
+        it("Reverts when non-owners try to pay from the budget", async function () {
+            await expect(Budget.connect(nonowner).pay(nonowner.address, 1)).to.be.revertedWith('Ownable: caller is not the owner');
+        });
+
+        describe("When owner pays from the budget", async function () {
+            beforeEach(async function () {
+                result = await Budget.pay(owner.address,1)
+            });
+
+            it("Decreases the budget", async function () {
+                expect(await Budget.balance()).to.equal(99);
+            });
+
+            it("Increases the balance of the payee address", async function () {
+                expect(await Token.balanceOf(owner.address)).to.equal(1);
+            });
+
+            it("Events a Payment Event", async function () {
+                await expect(result)
+                .to.emit(Budget, 'Payment')
+                .withArgs(owner.address, 1);
+            });
+        });
+        
+        describe("When owner sows a plot", async function () {
+            beforeEach(async function () {
+                this.result = await Budget.sow('10');
+            });
+
+            it("owns a plot", async function () {
+                expect(await field.plot(Budget.address, '0')).to.equal('10');
+            })
+        });
+
+        describe("When owner transfers a plot", async function () {
+            beforeEach(async function () {
+                this.result = await Budget.sow('10');
+                this.result = await Budget.payPlot(nonowner.address, '0', '0', '10');
+            });
+
+            it("user owns a plot", async function () {
+                expect(await field.plot(nonowner.address, '0')).to.equal('10');
+            })
+
+            it("Budget does not own a plot", async function () {
+                expect(await field.plot(Budget.address, '0')).to.equal('0');
+            })
+        });
+    });
+
+    describe("Upgrade", async function () {
+
+        beforeEach(async function () {
+            const BudgetOldFactory = await ethers.getContractFactory("BudgetOld");
+            OldBudget = await upgrades.deployProxy(BudgetOldFactory, [Token.address])
+            Token.mint(OldBudget.address, 100)
+
+            const BudgetFactory = await ethers.getContractFactory("Budget");
+            UpBudget = await upgrades.upgradeProxy(OldBudget.address, BudgetFactory);
+            await (await UpBudget.setBeanstalk(field.address)).wait()
         })
 
-        it("Decreases the budget", async function () {
-            expect(await Budget.balance()).to.equal(99);
+        describe("When owner pays from the budget", async function () {
+            beforeEach(async function () {
+                result = await UpBudget.pay(owner.address,1)
+            });
+
+            it("Decreases the budget", async function () {
+                expect(await UpBudget.balance()).to.equal(99);
+            });
+
+            it("Increases the balance of the payee address", async function () {
+                expect(await Token.balanceOf(owner.address)).to.equal(1);
+            });
+
+            it("Events a Payment Event", async function () {
+                await expect(result)
+                .to.emit(UpBudget, 'Payment')
+                .withArgs(owner.address, 1);
+            });
+        });
+    
+    describe("When owner sows a plot", async function () {
+        beforeEach(async function () {
+            this.result = await UpBudget.sow('10');
+        });
+
+        it("owns a plot", async function () {
+            expect(await field.plot(UpBudget.address, '0')).to.equal('10');
+        })
+    });
+
+    describe("When owner transfers a plot", async function () {
+        beforeEach(async function () {
+            this.result = await UpBudget.sow('10');
+            this.result = await UpBudget.payPlot(nonowner.address, '0', '0', '10');
+        });
+
+        it("user owns a plot", async function () {
+            expect(await field.plot(nonowner.address, '0')).to.equal('10');
         })
 
-        it("Increases the balance of the payee address", async function () {
-            expect(await Token.balanceOf(owner.address)).to.equal(1);
+        it("Budget does not own a plot", async function () {
+            expect(await field.plot(UpBudget.address, '0')).to.equal('0');
         })
-
-        it("Events a Payment Event", async function () {
-            await expect(result)
-            .to.emit(Budget, 'Payment')
-            .withArgs(owner.address, 1);
-        })
-    })
-  });
+    });
+    });
+});


### PR DESCRIPTION
Beanstalk Budged Improvement Proposal (BBIP) 1: Sowing Beans

Many of the people being paid from both the dev and marketing budgets have asked to have some or all of the Beans allocated to them sown immediately to lock in their place in the Pod Line and be paid the appropriate amount of Pods when payments are due. Having BeanstalkFarms members with incentives that are properly aligned with the long-term growth of Beanstalk is ideal. 

We propose an update to the budget contract that allows for budgeted Beans to be sown on behalf of the payee. The payee will then be paid in the form of a Plot instead of Beans.

Procedure: Anyone with an allocation from either budget currently not payable can request Publius sow all or a portion of their Beans. Publius will sow the requested amount of Beans and will make the payment in Pods. The number of Pods due is the number of Pods earned from sowing the Beans that were to be paid out. 

Upgrade: Upon passage of this proposal Publius will upgrade both budget contracts.